### PR TITLE
Correct id of the post-abduction mission counter

### DIFF
--- a/databases/me2_plot_db.ron
+++ b/databases/me2_plot_db.ron
@@ -193,7 +193,7 @@ Me2PlotDb(
                 3349: "Had casualties",
             },
             integers: {
-                166: "Number of missions after crew abducted (1-3 = half crew dead / 4 = all crew dead)",
+                23: "Number of missions after crew abducted (1-3 = half crew dead / 4 = all crew dead)",
             },
         ),
     },


### PR DESCRIPTION
I forgot how the Reaper IFF mission worked and accidentally did it too early. When I went to edit my save I noticed that the number of missions since the crew had been adbucted in the GUI wasn't incrementing as I wrapped up the last two loyalty missions. After comparing some deltas from different saves I determined that 23 was the correct ID and successfully set it to 0 to save the Normandy crew.

I'm playing on the legendary edition. I'm not sure if this was broken because of a difference between the original ME2 save format and the LE ME2 save format. If that's the case then I guess this would require a much more significant change to fix.